### PR TITLE
Update update.md

### DIFF
--- a/docs/update.md
+++ b/docs/update.md
@@ -1,7 +1,7 @@
 # To update the AV run the following:
 
 ```bash
-$ docker run --name=avira malice/avira update
+$ docker run --name avira malice/avira update
 ```
 
 ## Then to use the updated avira container:


### PR DESCRIPTION
--name=avira causes: 
malice@malice:~$ docker run --name=avira malice/avira update
Unable to find image 'malice/avira:latest' locally
docker: Error response from daemon: error parsing HTTP 404 response body: invalid character 'p' after top-level value: "404 page not found\n".
See 'docker run --help'.